### PR TITLE
Add bidirectional reading progress sync with Audiobookshelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
 # Audiobookshelf for KOReader
 
-This is a a KOReader plugin to allow you to browse and download books from an Audiobookshelf Server
+This is a KOReader plugin to browse, download books, and sync reading progress with an Audiobookshelf server.
 
 ## Installation
 
 1. Unzip the release into your KOReader plugins directory
 2. Copy the `audiobookshelf_config.example.lua` file to `audiobookshelf_config.lua`
-3. Add your Audiobookshelf user's API key as `token` in the config file.  This can be found on your audiobookshelf server at Settings > Users > Click your username
+3. Add your Audiobookshelf user's API key as `token` in the config file. This can be found on your Audiobookshelf server at Settings > Users > Click your username
 4. Add the `server` to the config file, specifically the url of your server (no trailing slash)
 
 ## Usage
 
-The Audiobookshelf Browser can be found in the tools menu. 
+The Audiobookshelf menu can be found in Tools > Audiobookshelf.
 
 ![FileManager_2025-04-14_164132](https://github.com/user-attachments/assets/99ccfb5c-67b7-47a9-bdd0-cca2ece99c4e)
 
-Once open, you can view the list of libraries available to your Audiobookshelf user
+### Browsing and Downloading
+
+Select "Browse library" to view the list of libraries available to your Audiobookshelf user.
 
 ![FileManager_2025-04-14_171731](https://github.com/user-attachments/assets/09d924c7-96d1-41d1-b68e-614da964cd63)
 
-Click on one, and you will get the list of books available from that library (this only returns Audiobookshelf items that contain at least one eBook file)
+Click on one, and you will get the list of books available from that library (this only returns Audiobookshelf items that contain at least one eBook file).
 
 ![FileManager_2025-04-14_171903](https://github.com/user-attachments/assets/423a5c74-2578-4361-bc5a-acdfc3286ddf)
 
@@ -30,3 +32,34 @@ If you click on a book, you go to the Book Details page, which gives details abo
 Click on the name of one of the Downloadable files, and follow the process to download the eBook.
 
 ![FileManager_2025-04-14_172211](https://github.com/user-attachments/assets/a05ce960-48ae-4bf7-a5a3-54b161a3b211)
+
+### Progress Sync
+
+The plugin can sync your reading progress between KOReader and Audiobookshelf.
+
+**Automatic linking:** Books downloaded through the plugin are automatically linked to their Audiobookshelf entry.
+
+**Manual linking:** For books you already have on your device, open the book, go to Tools > Audiobookshelf > "Not linked to Audiobookshelf", search for the book, and select the matching entry.
+
+**Sync triggers:**
+- **On book close:** Progress is pushed when you close a book
+- **On page turns:** Progress is pushed after a configurable number of page turns (default: 5)
+- **On book open:** Server progress is checked and you're prompted if it differs from local
+- **Manual:** Use "Push progress now" or "Pull progress now" from the menu
+
+**Settings:** Go to Tools > Audiobookshelf > Sync settings to configure:
+- Auto-push on book close (on/off)
+- Auto-push on page turns (on/off)
+- Pages before sync (1-50)
+- Auto-pull on book open (on/off)
+
+You can also set these in `audiobookshelf_config.lua`:
+
+```lua
+["sync"] = {
+    ["auto_push_on_close"] = true,
+    ["auto_push_on_page_turn"] = true,
+    ["page_threshold"] = 5,
+    ["auto_pull_on_open"] = true,
+}
+```

--- a/audiobookshelf/audiobookshelfapi.lua
+++ b/audiobookshelf/audiobookshelfapi.lua
@@ -1,4 +1,3 @@
-local config = require("audiobookshelf_config")
 local T = require("ffi/util").template
 local JSON = require("json")
 local http = require("socket.http")
@@ -16,233 +15,145 @@ local AudiobookshelfApi = {
     abs_settings = LuaSettings:open("plugins/audiobookshelf.koplugin/audiobookshelf_config.lua")
 }
 
-function AudiobookshelfApi:getLibraries()
-    local sink = {}
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/libraries",
-        method = "GET",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-        },
-        sink = ltn12.sink.table(sink),
+-- Execute an API request and return response body and code
+-- opts: { method, path, body, timeout_block, timeout_total, sink }
+function AudiobookshelfApi:request(opts)
+    local sink = opts.sink or {}
+    local use_table_sink = not opts.sink
+
+    local headers = {
+        ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
+        ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
     }
-    socketutil:set_timeout()
+    if opts.body then
+        headers["Content-Type"] = "application/json"
+        headers["Content-Length"] = #opts.body
+    end
+
+    local request = {
+        url = self.abs_settings:readSetting("server") .. opts.path,
+        method = opts.method or "GET",
+        headers = headers,
+        sink = use_table_sink and ltn12.sink.table(sink) or opts.sink,
+    }
+    if opts.body then
+        request.source = ltn12.source.string(opts.body)
+    end
+
+    if opts.timeout_block then
+        socketutil:set_timeout(opts.timeout_block, opts.timeout_total)
+    else
+        socketutil:set_timeout()
+    end
+
     local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    local response = table.concat(sink)
     socketutil:reset_timeout()
+
     if not ok then
-        logger.warn("AudiobookshelfApi: http request failed in getLibraries:", code)
-        return nil
+        return nil, nil, "network_error"
+    end
+
+    local response = use_table_sink and table.concat(sink) or nil
+    return response, code, status
+end
+
+-- Execute a GET request and decode JSON response
+function AudiobookshelfApi:get(path, opts)
+    opts = opts or {}
+    opts.path = path
+    opts.method = "GET"
+    local response, code, status = self:request(opts)
+
+    if not response then
+        logger.warn("AudiobookshelfApi: request failed:", path, status)
+        return nil, "network_error"
     end
     if code == 200 and response ~= "" then
-        local _, result = pcall(JSON.decode, response)
-        return result.libraries
+        local _, result = pcall(JSON.decode, response, JSON.decode.simple)
+        return result, code
     end
-    logger.warn("AudiobookshelfApi: cannot get libraries", status or code)
+    if code == 404 then
+        return nil, "not_found"
+    end
+    logger.warn("AudiobookshelfApi:", path, status or code)
     logger.warn("AudiobookshelfApi: error:", response)
-    return nil
+    return nil, "api_error"
+end
+
+function AudiobookshelfApi:getLibraries()
+    local result = self:get("/api/libraries")
+    return result and result.libraries
 end
 
 function AudiobookshelfApi:getLibraryItems(id)
-    local sink = {}
-    -- this is "ebooks" base64 encoded, and the URL encoded, to only return library items with ebooks
-    local filters = "ebooks." .. "ZWJvb2s%3D"
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/libraries/" .. id .. "/items?filter=" .. filters .. "&sort=media.metadata.title&limit=0",
-        method = "GET",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-        },
-        sink = ltn12.sink.table(sink),
-    }
-    socketutil:set_timeout()
-    local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    local response = table.concat(sink)
-    socketutil:reset_timeout()
-    if not ok then
-        logger.warn("AudiobookshelfApi: http request failed in getLibraryItems:", code)
-        return nil
-    end
-    if code == 200 and response ~= "" then
-        local _, result = pcall(JSON.decode, response, JSON.decode.simple)
-        return result.results
-    end
-    logger.warn("AudiobookshelfApi: cannot get library items for library", id ,status or code)
-    logger.warn("AudiobookshelfApi: error:", response)
-    return nil
+    -- "ebooks." + base64("ebook") url-encoded to filter for ebooks only
+    local filters = "ebooks.ZWJvb2s%3D"
+    local result = self:get("/api/libraries/" .. id .. "/items?filter=" .. filters .. "&sort=media.metadata.title&limit=0")
+    return result and result.results
 end
 
 function AudiobookshelfApi:getLibraryItem(id)
-    local sink = {}
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/items/" .. id .. "?expanded=1",
-        method = "GET",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-        },
-        sink = ltn12.sink.table(sink),
-    }
-    socketutil:set_timeout()
-    local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    local response = table.concat(sink)
-    socketutil:reset_timeout()
-    if not ok then
-        logger.warn("AudiobookshelfApi: http request failed in getLibraryItem:", code)
-        return nil
-    end
-    if code == 200 and response ~= "" then
-        local _, result = pcall(JSON.decode, response, JSON.decode.simple)
-        return result
-    end
-    logger.warn("AudiobookshelfApi: cannot get library item", id ,status or code)
-    logger.warn("AudiobookshelfApi: error:", response)
-    return nil
+    return self:get("/api/items/" .. id .. "?expanded=1")
 end
 
 function AudiobookshelfApi:downloadFile(id, ino, filename, local_path)
-    socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
     local outfile, err = io.open(local_path .. "/" .. filename, "w")
     if not outfile then
         logger.warn("AudiobookshelfApi: cannot open local file for writing:", local_path .. "/" .. filename, err)
-        socketutil:reset_timeout()
         return nil
     end
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/items/" .. id .. "/file/" .. ino .. "/download",
-        method = "GET",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-        },
+
+    local _, code = self:request({
+        path = "/api/items/" .. id .. "/file/" .. ino .. "/download",
         sink = ltn12.sink.file(outfile),
-    }
-    local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    socketutil:reset_timeout()
-    if not ok or code ~= 200 then
-        logger.warn("AudiobookshelfApi: cannot download file:", id , ino, status or code)
+        timeout_block = socketutil.FILE_BLOCK_TIMEOUT,
+        timeout_total = socketutil.FILE_TOTAL_TIMEOUT,
+    })
+
+    if code ~= 200 then
+        logger.warn("AudiobookshelfApi: cannot download file:", id, ino, code)
     end
     return code
 end
 
 function AudiobookshelfApi:getLibraryItemCover(id)
-    local sink = {}
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/items/" .. id .. "/cover?format=webp",
-        method = "GET",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-        },
-        sink = ltn12.sink.table(sink),
-    }
-    socketutil:set_timeout()
-    local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    local response = table.concat(sink)
-    socketutil:reset_timeout()
-    if not ok then
-        logger.warn("AudiobookshelfApi: http request failed in getLibraryItemCover:", code)
-        return nil
+    local response, code = self:request({ path = "/api/items/" .. id .. "/cover?format=webp" })
+    if code == 200 and response and response ~= "" then
+        return RenderImage:renderImageData(response, #response)
     end
-    if code == 200 and response ~= "" then
-        local result = RenderImage:renderImageData(response, #response)
-        return result
-    end
-    logger.warn("AudiobookshelfApi: cannot get library item cover", id ,status or code)
-    logger.warn("AudiobookshelfApi: error:", response)
+    logger.warn("AudiobookshelfApi: cannot get cover", id, code)
     return nil
 end
 
 function AudiobookshelfApi:getSearchResults(id, search_query)
-    local sink = {}
-    local url_encoded_search_string = util.urlEncode(search_query)
-    -- this is "ebooks" base64 encoded, and the URL encoded, to only return library items with ebooks
-    local filters = "ebooks." .. "ZWJvb2s%3D"
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/libraries/" .. id .. "/search?q=" .. url_encoded_search_string .. "&filter=" .. filters,
-        method = "GET",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-        },
-        sink = ltn12.sink.table(sink),
-    }
-    socketutil:set_timeout()
-    local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    local response = table.concat(sink)
-    socketutil:reset_timeout()
-    if not ok then
-        logger.warn("AudiobookshelfApi: http request failed in getSearchResults:", code)
-        return nil
-    end
-    if code == 200 and response ~= "" then
-        local _, result = pcall(JSON.decode, response, JSON.decode.simple)
-        return result
-    end
-    logger.warn("AudiobookshelfApi: cannot search library", id ,search_query, status or code)
-    logger.warn("AudiobookshelfApi: error:", response)
-    return nil
+    local filters = "ebooks.ZWJvb2s%3D"
+    local path = "/api/libraries/" .. id .. "/search?q=" .. util.urlEncode(search_query) .. "&filter=" .. filters
+    return self:get(path)
 end
 
 function AudiobookshelfApi:getProgress(library_item_id)
-    local sink = {}
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/me/progress/" .. library_item_id,
-        method = "GET",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-        },
-        sink = ltn12.sink.table(sink),
-    }
-    socketutil:set_timeout(5, 10)
-    local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    local response = table.concat(sink)
-    socketutil:reset_timeout()
-    if not ok then
-        logger.warn("AudiobookshelfApi: http request failed in getProgress:", code)
-        return nil, "network_error"
-    end
-    if code == 200 and response ~= "" then
-        local _, result = pcall(JSON.decode, response)
-        return result
-    elseif code == 404 then
-        return nil, "no_progress"
-    end
-    logger.warn("AudiobookshelfApi: cannot get progress", library_item_id, status or code)
-    return nil, "api_error"
+    return self:get("/api/me/progress/" .. library_item_id, { timeout_block = 5, timeout_total = 10 })
 end
 
 function AudiobookshelfApi:updateProgress(library_item_id, progress_data)
-    local sink = {}
     local body = JSON.encode(progress_data)
-    local request = {
-        url = self.abs_settings:readSetting("server") .. "/api/me/progress/" .. library_item_id,
+    local response, code, status = self:request({
+        path = "/api/me/progress/" .. library_item_id,
         method = "PATCH",
-        headers = {
-            ["Authorization"] = "Bearer " .. self.abs_settings:readSetting("token"),
-            ["User-Agent"] = T("audiobookshelf.koplugin/%1", table.concat(VERSION, ".")),
-            ["Content-Type"] = "application/json",
-            ["Content-Length"] = #body,
-        },
-        source = ltn12.source.string(body),
-        sink = ltn12.sink.table(sink),
-    }
-    socketutil:set_timeout(5, 10)
-    local ok, code, _, status = pcall(function() return socket.skip(1, http.request(request)) end)
-    local response = table.concat(sink)
-    socketutil:reset_timeout()
-    if not ok then
-        logger.warn("AudiobookshelfApi: http request failed in updateProgress:", code)
+        body = body,
+        timeout_block = 5,
+        timeout_total = 10,
+    })
+
+    if not response then
+        logger.warn("AudiobookshelfApi: updateProgress failed:", status)
         return nil, "network_error"
     end
     if code == 200 then
         local _, result = pcall(JSON.decode, response)
         return result
     end
-    logger.warn("AudiobookshelfApi: cannot update progress", library_item_id, status or code)
+    logger.warn("AudiobookshelfApi: cannot update progress", library_item_id, code)
     logger.warn("AudiobookshelfApi: error:", response)
     return nil, "api_error"
 end

--- a/audiobookshelf/bookdetailswidget.lua
+++ b/audiobookshelf/bookdetailswidget.lua
@@ -107,6 +107,7 @@ function BookDetailsWidget:genFileList()
                 filename = file.metadata.filename,
                 size_in_bytes =  file.metadata.size,
                 book_id = self.book_info.id,
+                book_title = self.book_info.media.metadata.title,
                 -- pass a zero-arg closure that will call this widget's onClose
                 onClose = function()
                     self:onClose()

--- a/audiobookshelf/bookmapping.lua
+++ b/audiobookshelf/bookmapping.lua
@@ -1,0 +1,65 @@
+local LuaSettings = require("luasettings")
+local logger = require("logger")
+
+local BookMapping = {
+    mappings_file = "plugins/audiobookshelf.koplugin/audiobookshelf_mappings.lua",
+    mappings = nil,
+}
+
+function BookMapping:init()
+    if self.mappings then
+        return
+    end
+    self.mappings = LuaSettings:open(self.mappings_file)
+end
+
+function BookMapping:getMapping(filepath)
+    self:init()
+    local mappings = self.mappings:readSetting("mappings") or {}
+    return mappings[filepath]
+end
+
+function BookMapping:setMapping(filepath, library_item_id, ebook_file_ino, title)
+    self:init()
+    local mappings = self.mappings:readSetting("mappings") or {}
+    mappings[filepath] = {
+        library_item_id = library_item_id,
+        ebook_file_ino = ebook_file_ino,
+        title = title,
+        linked_at = os.time(),
+        last_sync = nil,
+    }
+    self.mappings:saveSetting("mappings", mappings)
+    self.mappings:flush()
+    logger.dbg("BookMapping: linked", filepath, "to", library_item_id)
+end
+
+function BookMapping:updateLastSync(filepath)
+    self:init()
+    local mappings = self.mappings:readSetting("mappings") or {}
+    if mappings[filepath] then
+        mappings[filepath].last_sync = os.time()
+        self.mappings:saveSetting("mappings", mappings)
+        self.mappings:flush()
+    end
+end
+
+function BookMapping:removeMapping(filepath)
+    self:init()
+    local mappings = self.mappings:readSetting("mappings") or {}
+    if mappings[filepath] then
+        mappings[filepath] = nil
+        self.mappings:saveSetting("mappings", mappings)
+        self.mappings:flush()
+        logger.dbg("BookMapping: unlinked", filepath)
+        return true
+    end
+    return false
+end
+
+function BookMapping:getAllMappings()
+    self:init()
+    return self.mappings:readSetting("mappings") or {}
+end
+
+return BookMapping

--- a/audiobookshelf/progresssync.lua
+++ b/audiobookshelf/progresssync.lua
@@ -83,10 +83,8 @@ function ProgressSync:pushProgress(blocking, callback)
     end
 
     local progress_data = {
-        progress = local_progress.percent,
-        currentTime = 0,
-        isFinished = local_progress.percent >= 0.99,
         ebookProgress = local_progress.percent,
+        isFinished = local_progress.percent >= 0.99,
     }
 
     logger.dbg("ProgressSync: pushing progress", local_progress.percent, "to", self.current_mapping.library_item_id)

--- a/audiobookshelf/progresssync.lua
+++ b/audiobookshelf/progresssync.lua
@@ -1,0 +1,265 @@
+local AudiobookshelfApi = require("audiobookshelf/audiobookshelfapi")
+local BookMapping = require("audiobookshelf/bookmapping")
+local ConfirmBox = require("ui/widget/confirmbox")
+local InfoMessage = require("ui/widget/infomessage")
+local UIManager = require("ui/uimanager")
+local logger = require("logger")
+local _ = require("gettext")
+local T = require("ffi/util").template
+
+local ProgressSync = {
+    MIN_SYNC_INTERVAL = 25,
+    DEFAULT_PAGE_THRESHOLD = 5,
+
+    ui = nil,
+    last_sync_time = 0,
+    page_turn_count = 0,
+    current_mapping = nil,
+    pending_push = false,
+}
+
+function ProgressSync:init(ui)
+    self.ui = ui
+    self.last_sync_time = 0
+    self.page_turn_count = 0
+    self.current_mapping = nil
+    self.pending_push = false
+end
+
+function ProgressSync:loadMappingForDocument()
+    if not self.ui or not self.ui.document then
+        return nil
+    end
+    local filepath = self.ui.document.file
+    self.current_mapping = BookMapping:getMapping(filepath)
+    return self.current_mapping
+end
+
+function ProgressSync:calculateProgress()
+    if not self.ui or not self.ui.document then
+        return nil
+    end
+
+    local ok, current, total = pcall(function()
+        return self.ui:getCurrentPage(), self.ui.document:getPageCount()
+    end)
+
+    if not ok or not current or not total or total == 0 then
+        logger.warn("ProgressSync: failed to calculate progress")
+        return nil
+    end
+
+    return {
+        page = current,
+        total_pages = total,
+        percent = current / total,
+        timestamp = os.time(),
+    }
+end
+
+function ProgressSync:shouldSync()
+    local now = os.time()
+    if now - self.last_sync_time < self.MIN_SYNC_INTERVAL then
+        return false
+    end
+    return true
+end
+
+function ProgressSync:pushProgress(blocking, callback)
+    if not self.current_mapping then
+        logger.dbg("ProgressSync: no mapping, skipping push")
+        if callback then callback(false, "no_mapping") end
+        return
+    end
+
+    if not self:shouldSync() and not blocking then
+        logger.dbg("ProgressSync: debounced, skipping push")
+        if callback then callback(false, "debounced") end
+        return
+    end
+
+    local local_progress = self:calculateProgress()
+    if not local_progress then
+        if callback then callback(false, "no_progress") end
+        return
+    end
+
+    local progress_data = {
+        progress = local_progress.percent,
+        currentTime = 0,
+        isFinished = local_progress.percent >= 0.99,
+        ebookProgress = local_progress.percent,
+    }
+
+    logger.dbg("ProgressSync: pushing progress", local_progress.percent, "to", self.current_mapping.library_item_id)
+
+    local result, err = AudiobookshelfApi:updateProgress(
+        self.current_mapping.library_item_id,
+        progress_data
+    )
+
+    if result then
+        self.last_sync_time = os.time()
+        BookMapping:updateLastSync(self.ui.document.file)
+        logger.dbg("ProgressSync: push successful")
+        if callback then callback(true) end
+    else
+        logger.dbg("ProgressSync: push failed:", err)
+        if callback then callback(false, err) end
+    end
+end
+
+function ProgressSync:pullProgress(callback)
+    if not self.current_mapping then
+        logger.dbg("ProgressSync: no mapping, skipping pull")
+        if callback then callback(false, "no_mapping") end
+        return
+    end
+
+    logger.dbg("ProgressSync: pulling progress for", self.current_mapping.library_item_id)
+
+    local server_progress, err = AudiobookshelfApi:getProgress(self.current_mapping.library_item_id)
+
+    if err == "no_progress" then
+        logger.dbg("ProgressSync: no server progress exists")
+        if callback then callback(true, nil) end
+        return
+    end
+
+    if not server_progress then
+        logger.warn("ProgressSync: pull failed:", err)
+        if callback then callback(false, err) end
+        return
+    end
+
+    if callback then callback(true, server_progress) end
+end
+
+function ProgressSync:checkAndPromptServerProgress(show_no_diff_message)
+    self:pullProgress(function(success, server_progress)
+        if not success then
+            if show_no_diff_message then
+                UIManager:show(InfoMessage:new{
+                    text = _("Could not fetch progress from server."),
+                    timeout = 3,
+                })
+            end
+            return
+        end
+
+        if not server_progress then
+            if show_no_diff_message then
+                UIManager:show(InfoMessage:new{
+                    text = _("No progress on server yet."),
+                    timeout = 2,
+                })
+            end
+            return
+        end
+
+        local local_progress = self:calculateProgress()
+        if not local_progress then
+            return
+        end
+
+        local server_percent = server_progress.ebookProgress or server_progress.progress or 0
+        local local_percent = local_progress.percent
+
+        local diff = math.abs(server_percent - local_percent)
+        if diff < 0.01 then
+            if show_no_diff_message then
+                UIManager:show(InfoMessage:new{
+                    text = _("Progress is already in sync."),
+                    timeout = 2,
+                })
+            end
+            return
+        end
+
+        local server_page = math.floor(server_percent * local_progress.total_pages)
+        local server_time_str = ""
+        if server_progress.lastUpdate then
+            server_time_str = os.date("%Y-%m-%d %H:%M", server_progress.lastUpdate / 1000)
+        end
+
+        local message
+        if server_percent > local_percent then
+            message = T(_("Server is ahead of local.\n\nLocal: Page %1 (%2%%)\nServer: Page %3 (%4%%)\nServer updated: %5\n\nJump to server position?"),
+                local_progress.page,
+                math.floor(local_percent * 100),
+                server_page,
+                math.floor(server_percent * 100),
+                server_time_str
+            )
+        else
+            message = T(_("Server is behind local.\n\nLocal: Page %1 (%2%%)\nServer: Page %3 (%4%%)\nServer updated: %5\n\nGo back to server position?"),
+                local_progress.page,
+                math.floor(local_percent * 100),
+                server_page,
+                math.floor(server_percent * 100),
+                server_time_str
+            )
+        end
+
+        UIManager:show(ConfirmBox:new{
+            text = message,
+            ok_text = _("Use server"),
+            cancel_text = _("Keep local"),
+            ok_callback = function()
+                self:applyServerProgress(server_progress)
+            end,
+        })
+    end)
+end
+
+function ProgressSync:applyServerProgress(server_progress)
+    if not self.ui or not self.ui.document then
+        return
+    end
+
+    local total_pages = self.ui.document:getPageCount()
+    local server_percent = server_progress.ebookProgress or server_progress.progress or 0
+    local target_page = math.floor(server_percent * total_pages)
+    target_page = math.max(1, math.min(target_page, total_pages))
+
+    logger.dbg("ProgressSync: applying server progress, going to page", target_page)
+
+    local Event = require("ui/event")
+    self.ui:handleEvent(Event:new("GotoPage", target_page))
+
+    UIManager:show(InfoMessage:new{
+        text = T(_("Moved to page %1."), target_page),
+        timeout = 2,
+    })
+end
+
+function ProgressSync:onPageTurn(settings)
+    if not self.current_mapping then
+        return
+    end
+
+    local auto_sync = settings and settings.auto_push_on_page_turn
+    if auto_sync == false then
+        return
+    end
+
+    self.page_turn_count = self.page_turn_count + 1
+
+    local threshold = (settings and settings.page_threshold) or self.DEFAULT_PAGE_THRESHOLD
+    if self.page_turn_count >= threshold then
+        self.page_turn_count = 0
+        if self:shouldSync() then
+            self:pushProgress(false)
+        end
+    end
+end
+
+function ProgressSync:reset()
+    self.ui = nil
+    self.last_sync_time = 0
+    self.page_turn_count = 0
+    self.current_mapping = nil
+    self.pending_push = false
+end
+
+return ProgressSync

--- a/audiobookshelf/progresssync.lua
+++ b/audiobookshelf/progresssync.lua
@@ -15,7 +15,6 @@ local ProgressSync = {
     last_sync_time = 0,
     page_turn_count = 0,
     current_mapping = nil,
-    pending_push = false,
 }
 
 function ProgressSync:init(ui)
@@ -23,7 +22,6 @@ function ProgressSync:init(ui)
     self.last_sync_time = 0
     self.page_turn_count = 0
     self.current_mapping = nil
-    self.pending_push = false
 end
 
 function ProgressSync:loadMappingForDocument()
@@ -259,7 +257,6 @@ function ProgressSync:reset()
     self.last_sync_time = 0
     self.page_turn_count = 0
     self.current_mapping = nil
-    self.pending_push = false
 end
 
 return ProgressSync

--- a/audiobookshelf_config.example.lua
+++ b/audiobookshelf_config.example.lua
@@ -1,5 +1,13 @@
 -- plugins/audiobookshelf.koplugin/audiobookshelf_config.lua
 return {
     ["token"] = 'your api key here',
-    ["server"] = 'your audiobookshelf instance url here'
+    ["server"] = 'your audiobookshelf instance url here',
+
+    -- Sync settings (optional - these are the defaults)
+    ["sync"] = {
+        ["auto_push_on_close"] = true,      -- Push progress when closing a book
+        ["auto_push_on_page_turn"] = true,  -- Push progress after N page turns
+        ["page_threshold"] = 5,             -- Number of page turns before syncing (1-50)
+        ["auto_pull_on_open"] = true,       -- Check server progress when opening a book
+    },
 }

--- a/main.lua
+++ b/main.lua
@@ -1,32 +1,397 @@
 local Dispatcher = require("dispatcher")
+local AudiobookshelfApi = require("audiobookshelf/audiobookshelfapi")
 local AudiobookshelfBrowser = require("audiobookshelf/audiobookshelfbrowser")
+local BookMapping = require("audiobookshelf/bookmapping")
+local ProgressSync = require("audiobookshelf/progresssync")
+local ButtonDialogTitle = require("ui/widget/buttondialogtitle")
+local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
+local SpinWidget = require("ui/widget/spinwidget")
 local UIManager = require("ui/uimanager")
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local LuaSettings = require("luasettings")
 local _ = require("gettext")
 local logger = require("logger")
 
 local Audiobookshelf = WidgetContainer:extend{
     name = "audiobookshelf",
     is_doc_only = false,
+    settings = nil,
 }
 
 function Audiobookshelf:onDispatcherRegisterActions()
-    -- none atm
+    Dispatcher:registerAction("abs_push_progress", {
+        category = "none",
+        event = "ABSPushProgress",
+        title = _("Push progress to Audiobookshelf"),
+        general = true,
+    })
+    Dispatcher:registerAction("abs_pull_progress", {
+        category = "none",
+        event = "ABSPullProgress",
+        title = _("Pull progress from Audiobookshelf"),
+        general = true,
+    })
 end
 
 function Audiobookshelf:init()
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
+    self:loadSettings()
+
+    if self.ui.document then
+        self:initSyncForDocument()
+    end
+end
+
+function Audiobookshelf:loadSettings()
+    self.settings = LuaSettings:open("plugins/audiobookshelf.koplugin/audiobookshelf_config.lua")
+end
+
+function Audiobookshelf:getSyncSettings()
+    if not self.settings then
+        self:loadSettings()
+    end
+    return self.settings:readSetting("sync") or {
+        enabled = true,
+        auto_push_on_close = true,
+        auto_push_on_page_turn = true,
+        page_threshold = 5,
+        auto_pull_on_open = true,
+        show_notifications = true,
+    }
+end
+
+function Audiobookshelf:saveSyncSetting(key, value)
+    local sync_settings = self:getSyncSettings()
+    sync_settings[key] = value
+    self.settings:saveSetting("sync", sync_settings)
+    self.settings:flush()
+end
+
+function Audiobookshelf:initSyncForDocument()
+    ProgressSync:init(self.ui)
+    ProgressSync:loadMappingForDocument()
+end
+
+function Audiobookshelf:onReaderReady()
+    self:initSyncForDocument()
+
+    local sync_settings = self:getSyncSettings()
+    if sync_settings.auto_pull_on_open and ProgressSync.current_mapping then
+        UIManager:scheduleIn(0.5, function()
+            ProgressSync:checkAndPromptServerProgress(false)
+        end)
+    end
+end
+
+function Audiobookshelf:onPageUpdate(pageno)
+    local sync_settings = self:getSyncSettings()
+    ProgressSync:onPageTurn(sync_settings)
+end
+
+function Audiobookshelf:onCloseDocument()
+    local sync_settings = self:getSyncSettings()
+    if sync_settings.auto_push_on_close and ProgressSync.current_mapping then
+        ProgressSync:pushProgress(true)
+    end
+    ProgressSync:reset()
+end
+
+function Audiobookshelf:onABSPushProgress()
+    if not ProgressSync.current_mapping then
+        UIManager:show(InfoMessage:new{
+            text = _("This book is not linked to Audiobookshelf."),
+            timeout = 3,
+        })
+        return true
+    end
+
+    ProgressSync:pushProgress(true, function(success, err)
+        if success then
+            UIManager:show(InfoMessage:new{
+                text = _("Progress pushed to server."),
+                timeout = 2,
+            })
+        else
+            UIManager:show(InfoMessage:new{
+                text = _("Failed to push progress."),
+                timeout = 3,
+            })
+        end
+    end)
+    return true
+end
+
+function Audiobookshelf:onABSPullProgress()
+    if not ProgressSync.current_mapping then
+        UIManager:show(InfoMessage:new{
+            text = _("This book is not linked to Audiobookshelf."),
+            timeout = 3,
+        })
+        return true
+    end
+
+    ProgressSync:checkAndPromptServerProgress(true)
+    return true
 end
 
 function Audiobookshelf:addToMainMenu(menu_items)
     menu_items.audiobookshelf = {
         text = _("Audiobookshelf"),
         sorting_hint = "tools",
-        callback = function()
-            UIManager:show(AudiobookshelfBrowser:new())
-        end
+        sub_item_table = {
+            {
+                text = _("Browse library"),
+                callback = function()
+                    UIManager:show(AudiobookshelfBrowser:new())
+                end,
+                separator = true,
+            },
+            {
+                text = _("Push progress now"),
+                enabled_func = function()
+                    return ProgressSync.current_mapping ~= nil
+                end,
+                callback = function()
+                    self:onABSPushProgress()
+                end,
+            },
+            {
+                text = _("Pull progress now"),
+                enabled_func = function()
+                    return ProgressSync.current_mapping ~= nil
+                end,
+                callback = function()
+                    self:onABSPullProgress()
+                end,
+            },
+            {
+                text_func = function()
+                    if ProgressSync.current_mapping then
+                        return _("Linked: ") .. (ProgressSync.current_mapping.title or "Unknown")
+                    else
+                        return _("Not linked to Audiobookshelf")
+                    end
+                end,
+                enabled_func = function()
+                    return self.ui.document ~= nil
+                end,
+                callback = function()
+                    if ProgressSync.current_mapping then
+                        self:showUnlinkDialog()
+                    else
+                        self:showLinkDialog()
+                    end
+                end,
+                separator = true,
+            },
+            {
+                text = _("Sync settings"),
+                sub_item_table = self:getSyncSettingsMenu(),
+            },
+        },
     }
+end
+
+function Audiobookshelf:getSyncSettingsMenu()
+    return {
+        {
+            text = _("Auto-push on book close"),
+            checked_func = function()
+                return self:getSyncSettings().auto_push_on_close
+            end,
+            callback = function()
+                local current = self:getSyncSettings().auto_push_on_close
+                self:saveSyncSetting("auto_push_on_close", not current)
+            end,
+        },
+        {
+            text = _("Auto-push on page turns"),
+            checked_func = function()
+                return self:getSyncSettings().auto_push_on_page_turn
+            end,
+            callback = function()
+                local current = self:getSyncSettings().auto_push_on_page_turn
+                self:saveSyncSetting("auto_push_on_page_turn", not current)
+            end,
+        },
+        {
+            text_func = function()
+                local threshold = self:getSyncSettings().page_threshold or 5
+                return _("Pages before sync: ") .. threshold
+            end,
+            callback = function()
+                local current = self:getSyncSettings().page_threshold or 5
+                local spin_widget = SpinWidget:new{
+                    title_text = _("Pages before sync"),
+                    info_text = _("Sync progress after this many page turns."),
+                    value = current,
+                    value_min = 1,
+                    value_max = 50,
+                    value_step = 1,
+                    default_value = 5,
+                    callback = function(spin)
+                        self:saveSyncSetting("page_threshold", spin.value)
+                    end,
+                }
+                UIManager:show(spin_widget)
+            end,
+            keep_menu_open = true,
+            separator = true,
+        },
+        {
+            text = _("Auto-pull on book open"),
+            checked_func = function()
+                return self:getSyncSettings().auto_pull_on_open
+            end,
+            callback = function()
+                local current = self:getSyncSettings().auto_pull_on_open
+                self:saveSyncSetting("auto_pull_on_open", not current)
+            end,
+        },
+    }
+end
+
+function Audiobookshelf:showUnlinkDialog()
+    local ConfirmBox = require("ui/widget/confirmbox")
+    UIManager:show(ConfirmBox:new{
+        text = _("Unlink this book from Audiobookshelf?\n\nProgress will no longer sync for this book."),
+        ok_text = _("Unlink"),
+        ok_callback = function()
+            if self.ui.document then
+                BookMapping:removeMapping(self.ui.document.file)
+                ProgressSync.current_mapping = nil
+                UIManager:show(InfoMessage:new{
+                    text = _("Book unlinked."),
+                    timeout = 2,
+                })
+            end
+        end,
+    })
+end
+
+function Audiobookshelf:showLinkDialog()
+    if not self.ui.document then
+        return
+    end
+
+    local doc_props = self.ui.document:getProps()
+    local default_search = doc_props.title or self.ui.document.file:match("([^/]+)%.[^.]+$") or ""
+
+    self.link_dialog = InputDialog:new{
+        title = _("Search Audiobookshelf to link this book"),
+        input = default_search,
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id = "close",
+                    callback = function()
+                        UIManager:close(self.link_dialog)
+                    end,
+                },
+                {
+                    text = _("Search"),
+                    is_enter_default = true,
+                    callback = function()
+                        local query = self.link_dialog:getInputText()
+                        UIManager:close(self.link_dialog)
+                        if query and #query > 0 then
+                            self:searchAndShowLinkResults(query)
+                        end
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(self.link_dialog)
+    self.link_dialog:onShowKeyboard()
+end
+
+function Audiobookshelf:searchAndShowLinkResults(query)
+    local libraries = AudiobookshelfApi:getLibraries()
+    if not libraries or #libraries == 0 then
+        UIManager:show(InfoMessage:new{
+            text = _("Could not connect to Audiobookshelf. Check settings."),
+            timeout = 3,
+        })
+        return
+    end
+
+    local all_results = {}
+    for _, library in ipairs(libraries) do
+        local results = AudiobookshelfApi:getSearchResults(library.id, query)
+        if results and results.book then
+            for _, item in ipairs(results.book) do
+                -- Only include items that have an ebook file
+                if item.libraryItem.media and item.libraryItem.media.ebookFile then
+                    table.insert(all_results, {
+                        id = item.libraryItem.id,
+                        title = item.libraryItem.media.metadata.title,
+                        author = item.libraryItem.media.metadata.authorName,
+                    })
+                end
+            end
+        end
+    end
+
+    if #all_results == 0 then
+        UIManager:show(InfoMessage:new{
+            text = _("No books found. Try a different search."),
+            timeout = 3,
+        })
+        return
+    end
+
+    self:showLinkResultsDialog(all_results)
+end
+
+function Audiobookshelf:showLinkResultsDialog(results)
+    local buttons = {}
+
+    for i, result in ipairs(results) do
+        if i > 10 then break end
+        table.insert(buttons, {
+            {
+                text = result.title .. "\n" .. (result.author or ""),
+                callback = function()
+                    UIManager:close(self.results_dialog)
+                    self:linkToBook(result.id, result.title)
+                end,
+            },
+        })
+    end
+
+    table.insert(buttons, {
+        {
+            text = _("Cancel"),
+            callback = function()
+                UIManager:close(self.results_dialog)
+            end,
+        },
+    })
+
+    self.results_dialog = ButtonDialogTitle:new{
+        title = _("Select book to link"),
+        buttons = buttons,
+    }
+    UIManager:show(self.results_dialog)
+end
+
+function Audiobookshelf:linkToBook(library_item_id, title)
+    if not self.ui.document then
+        return
+    end
+
+    local filepath = self.ui.document.file
+    BookMapping:setMapping(filepath, library_item_id, nil, title)
+    ProgressSync:loadMappingForDocument()
+
+    UIManager:show(InfoMessage:new{
+        text = _("Book linked to: ") .. title,
+        timeout = 2,
+    })
 end
 
 return Audiobookshelf


### PR DESCRIPTION
Add bidirectional reading progress sync with Audiobookshelf

- Push progress on book close, page turns (configurable threshold), or manually
- Pull progress on book open with prompt when server differs from local
- Auto-link books downloaded through the plugin
- Manual linking via search for existing books (ebook-only results)
- Conflict resolution dialog showing local vs server progress with timestamps
- Different prompts for "server ahead" vs "server behind" scenarios
- Configurable sync settings via menu or config file

New files:
- audiobookshelf/bookmapping.lua: Persistent file-to-library-item mapping
  using LuaSettings, stores library_item_id, ebook_file_ino, title, last_sync
- audiobookshelf/progresssync.lua: Core sync logic with 25s debouncing,
  page turn counting, progress calculation (page/total as 0-1 decimal)

Modified files:
- audiobookshelfapi.lua: Consolidate request logic and add getProgress() and updateProgress() methods
  for /api/me/progress/{id} endpoint, uses ebookProgress field
- main.lua: Add event handlers (onReaderReady, onPageUpdate, onCloseDocument),
  dispatcher actions for gestures, expanded menu with sync options and
  settings submenu, manual link/unlink dialogs with search
- ebookfilewidget.lua: Auto-link downloaded books via BookMapping
- bookdetailswidget.lua: Pass book_title to EbookFileWidget for linking
- audiobookshelf_config.example.lua: Document sync settings
- README.md: Add Progress Sync documentation section

Notes:
- An attempt at https://github.com/naleo/audiobookshelf.koplugin/issues/4
- Does push the browser into a nested menu item, which may not be wanted.
- Manually tested on a Voyage  running KoReader 2025.10 against ABS v2.32.1